### PR TITLE
Introduce the concept of a foreign argument.

### DIFF
--- a/typ/arg_parser.py
+++ b/typ/arg_parser.py
@@ -280,6 +280,8 @@ class ArgumentParser(argparse.ArgumentParser):
             v = d[k]
             argname = _argname_from_key(k)
             action = self._action_for_key(k)
+            if not action:
+              continue
             action_str = _action_str(action)
             if k == 'tests':
                 tests = v
@@ -310,8 +312,9 @@ class ArgumentParser(argparse.ArgumentParser):
             if action.dest == key:
                 return action
 
-        assert False, ('Could not find an action for %s'  # pragma: no cover
-                       % key)
+        # Assume foreign argument: something used by the embedder of typ, for
+        # example.
+        return None
 
 
 def _action_str(action):

--- a/typ/arg_parser.py
+++ b/typ/arg_parser.py
@@ -281,7 +281,7 @@ class ArgumentParser(argparse.ArgumentParser):
             argname = _argname_from_key(k)
             action = self._action_for_key(k)
             if not action:
-              continue
+                continue
             action_str = _action_str(action)
             if k == 'tests':
                 tests = v

--- a/typ/tests/arg_parser_test.py
+++ b/typ/tests/arg_parser_test.py
@@ -44,6 +44,13 @@ class ArgumentParserTest(unittest.TestCase):
         check(['--jobs', '3'])
         check(['-vv'], ['--verbose', '--verbose'])
 
+    def test_argv_from_args_foreign_argument(self):
+        parser = ArgumentParser()
+        parser.add_argument('--some-foreign-argument', default=False,
+                            action='store_true')
+        args = parser.parse_args(['--some-foreign-argument', '--verbose'])
+        self.assertEqual(['--verbose'], ArgumentParser().argv_from_args(args))
+
     def test_valid_shard_options(self):
         parser = ArgumentParser()
 


### PR DESCRIPTION
When an embedding application wants to integrate its argument
handling with typ, it can re-use typ's ArgumentParser subclass
and add its own arguments to it. They will be ignored and
not passed to spawned instances of typ.