### PR TITLE
Add support for cleanup hook.

### DIFF
--- a/typ/runner.py
+++ b/typ/runner.py
@@ -110,6 +110,7 @@ class Runner(object):
         self.setup_fn = None
         self.stats = None
         self.teardown_fn = None
+        self.cleanup_fn = None
         self.top_level_dir = None
         self.top_level_dirs = []
         self.win_multiprocessing = WinMultiprocessing.spawn
@@ -533,7 +534,7 @@ class Runner(object):
 
         child = _Child(self)
         pool = make_pool(h, jobs, _run_one_test, child,
-                         _setup_process, _teardown_process)
+                         _setup_process, _teardown_process, self.cleanup_fn)
         try:
             while test_inputs or running_jobs:
                 while test_inputs and (len(running_jobs) < self.args.jobs):

--- a/typ/tests/pool_test.py
+++ b/typ/tests/pool_test.py
@@ -51,7 +51,7 @@ class TestPool(test_case.TestCase):
     def run_basic_test(self, jobs):
         host = Host()
         context = {'pre': False, 'post': False}
-        pool = make_pool(host, jobs, _echo, context, _pre, _post)
+        pool = make_pool(host, jobs, _echo, context, _pre, _post, None)
         pool.send('hello')
         pool.send('world')
         msg1 = pool.get()
@@ -71,7 +71,7 @@ class TestPool(test_case.TestCase):
             host = pool.host
         else:
             host = Host()
-            pool = _ProcessPool(host, 0, _stub, None, _stub, _stub)
+            pool = _ProcessPool(host, 0, _stub, None, _stub, _stub, None)
             pool.send('hello')
 
         worker_num = 1
@@ -81,7 +81,7 @@ class TestPool(test_case.TestCase):
 
     def test_async_close(self):
         host = Host()
-        pool = make_pool(host, 1, _echo, None, _stub, _stub)
+        pool = make_pool(host, 1, _echo, None, _stub, _stub, None)
         pool.join()
 
     def test_basic_one_job(self):
@@ -93,7 +93,7 @@ class TestPool(test_case.TestCase):
     def test_join_discards_messages(self):
         host = Host()
         context = {'pre': False, 'post': False}
-        pool = make_pool(host, 2, _echo, context, _pre, _post)
+        pool = make_pool(host, 2, _echo, context, _pre, _post, None)
         pool.send('hello')
         pool.close()
         pool.join()
@@ -102,7 +102,7 @@ class TestPool(test_case.TestCase):
     @unittest.skipIf(sys.version_info.major == 3, 'fails under python3')
     def test_join_gets_an_error(self):
         host = Host()
-        pool = make_pool(host, 2, _error, None, _stub, _stub)
+        pool = make_pool(host, 2, _error, None, _stub, _stub, None)
         pool.send('hello')
         pool.close()
         try:
@@ -112,7 +112,7 @@ class TestPool(test_case.TestCase):
 
     def test_join_gets_an_interrupt(self):
         host = Host()
-        pool = make_pool(host, 2, _interrupt, None, _stub, _stub)
+        pool = make_pool(host, 2, _interrupt, None, _stub, _stub, None)
         pool.send('hello')
         pool.close()
         self.assertRaises(KeyboardInterrupt, pool.join)
@@ -158,15 +158,76 @@ class TestPool(test_case.TestCase):
         host = Host()
         jobs = 2
         self.assertRaises(Exception, make_pool,
-                          host, jobs, _stub, unpicklable_fn, None, None)
+                          host, jobs, _stub, unpicklable_fn, None, None, None)
         self.assertRaises(Exception, make_pool,
-                          host, jobs, _stub, None, unpicklable_fn, None)
+                          host, jobs, _stub, None, unpicklable_fn, None, None)
         self.assertRaises(Exception, make_pool,
-                          host, jobs, _stub, None, None, unpicklable_fn)
+                          host, jobs, _stub, None, None, unpicklable_fn, None)
 
     def test_no_close(self):
         host = Host()
         context = {'pre': False, 'post': False}
-        pool = make_pool(host, 2, _echo, context, _pre, _post)
+        pool = make_pool(host, 2, _echo, context, _pre, _post, None)
         final_contexts = pool.join()
         self.assertEqual(final_contexts, [])
+
+    def test_serial_cleanup(self):
+        host = Host()
+        context = {'pre': False, 'post': False}
+
+        class Callback(object):
+
+            def __init__(self, test):
+                self.test = test
+                self.called = False
+                self.dirty = False
+
+            def run(self, context, msg):
+                self.called = True
+                self.test.assertFalse(self.dirty)
+                self.dirty = True
+
+            def cleanup(self):
+                self.dirty = False
+
+        cb = Callback(self)
+
+        pool = make_pool(host, 1, cb.run, context, _pre, _post, cb.cleanup)
+        pool.send('hello')
+        pool.send('another')
+        pool.get()
+
+        pool.send('world')
+        pool.get()
+        pool.get()
+        pool.close()
+        pool.join()
+
+        self.assertTrue(cb.called)
+
+    def test_parallel_cleanup(self):
+        host = Host()
+        context = {'pre': False, 'post': False}
+
+        class Callback(object):
+
+            def __init__(self):
+                self.dirty = True
+
+            def cleanup(self):
+                self.dirty = False
+
+        cb = Callback()
+
+        pool = make_pool(host, 2, _echo, context, _pre, _post, cb.cleanup)
+        pool.send('hello')
+        pool.send('another')
+        pool.get()
+
+        pool.send('world')
+        pool.get()
+        pool.get()
+        pool.close()
+        pool.join()
+
+        self.assertFalse(cb.dirty)


### PR DESCRIPTION
The hook may be useful if the embedder wishes to clean up some global state
(which may leak out of flaky tests) to prevent interferention with other tests
that may depend on this state.

The hook is run once after tearing down all the processes in parallel pool and
after each test in async pool to allow cleanup after each test is run (may be
essential to fully isolate tests in serial retry runs).