### PR TITLE
Skip retries if there are many broken tests.

### DIFF
--- a/typ/arg_parser.py
+++ b/typ/arg_parser.py
@@ -166,6 +166,9 @@ class ArgumentParser(argparse.ArgumentParser):
             self.add_argument('--no-overwrite', action='store_false',
                               dest='overwrite', default=None,
                               help=argparse.SUPPRESS)
+            self.add_argument('--broken-threshold', type=int, default=20,
+                              help=('Maximum number of failed tests that '
+                                    'will be restarted.'))
 
         if discovery or running:
             self.add_argument('-P', '--path', action='append', default=[],

--- a/typ/runner.py
+++ b/typ/runner.py
@@ -467,6 +467,11 @@ class Runner(object):
         failed_tests = sorted(json_results.failed_test_names(result_set))
         retry_limit = self.args.retry_limit
 
+        if retry_limit and len(failed_tests) > self.args.broken_threshold:
+            self.print_('Too many failed tests %d, skipping retries.' %
+                        len(failed_tests))
+            retry_limit = 0
+
         while retry_limit and failed_tests:
             if retry_limit == self.args.retry_limit:
                 self.flush()


### PR DESCRIPTION
Hi.

We use your runner for telemetry unit tests in Yandex browser (Chromium fork).
Time to time we get timeouts if running tests with unstable browser.
In this case many test failed, and runner tried to restart them several times.

I'm try to fix it the same way as gtest launcher does. There is a limit for maximum failed test count.
https://cs.chromium.org/chromium/src/base/test/launcher/test_launcher.cc?type=cs&sq=package:chromium&l=740

Unit-tests build will stop running if there is many failed and also will skip retries.
I've implemented only skipping retries. But can do the first part if it makes sense.